### PR TITLE
Update minimum Home Assistant Core version

### DIFF
--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -10,7 +10,7 @@ ingress_port: 0
 ingress_stream: true
 panel_icon: mdi:sitemap
 init: false
-homeassistant: 2021.3.0
+homeassistant: 2023.3.0
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION

# Proposed Changes

node-red-contrib-home-assistant-websocket v0.55.0 minimum version of Home Assistant Core is 2023.3.0 due to it using a websocket endpoint that was introduced in that version.


